### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 reflex==0.6.7
 reflex-local-auth>=0.2.2
 PyYAML==6.0.2
-atlassian-python-api=3.41.16
+atlassian-python-api==3.41.16


### PR DESCRIPTION
Updated the version specification for atlassian-python-api from = to == in the requirements.txt file.
This resolves the syntax error encountered during pip install -r requirements.txt.