### PR TITLE
Fix debug logging persistence and add regression test

### DIFF
--- a/galadriel/utils/debug.py
+++ b/galadriel/utils/debug.py
@@ -32,5 +32,6 @@ def log(message:str, final_log:bool = False):
         
         print(f"[{module}] " + message)
 
-        enabled = final_log
-        if final_log: global_module = ""
+        enabled = not final_log
+        if final_log:
+            global_module = ""

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,28 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_debug_module():
+    module_path = Path(__file__).resolve().parents[1] / "galadriel" / "utils" / "debug.py"
+    spec = importlib.util.spec_from_file_location("debug", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_logging_remains_enabled_until_final(capsys):
+    debug = _load_debug_module()
+    debug.set_log(True)
+    debug.set_module("TEST")
+    debug.log("first")
+    debug.log("second")
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["[TEST] first", "[TEST] second"]
+
+    debug.log("third", True)
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["[TEST] third"]
+
+    debug.log("fourth")
+    out = capsys.readouterr().out.splitlines()
+    assert out == []


### PR DESCRIPTION
## Summary
- Keep debug logging active until a final log call
- Cover debug logger behavior with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a7efbc2ec8331ae214207d84850c5