### PR TITLE
Fix YAML write_setting to create missing config files

### DIFF
--- a/galadriel/utils/yaml.py
+++ b/galadriel/utils/yaml.py
@@ -1,3 +1,19 @@
+"""YAML helper functions.
+
+This module exposes two small helpers for reading and writing settings to a
+YAML file.  The previous implementation of :func:`write_setting` assumed that
+the configuration file and the desired section already existed.  When the file
+or section was missing a ``KeyError`` or ``FileNotFoundError`` was raised and
+silently swallowed, leaving the file untouched.  As a consequence calls such
+as ``write_setting('galadriel.yaml', 'galadriel', 'first_run', 1)`` would fail
+when ``galadriel.yaml`` did not yet exist – exactly the situation that happens
+on the first run of the application.
+
+The function now creates the configuration file (and any missing sections)
+when necessary so the setting is reliably written.
+"""
+
+import os
 import yaml
 
 def read_setting(filename:str, section:str, key:str):
@@ -10,11 +26,28 @@ def read_setting(filename:str, section:str, key:str):
     return setting
 
 def write_setting(filename:str, section:str, key:str, value):
+    """Write ``value`` under ``section`` and ``key`` to ``filename``.
+
+    The previous implementation failed silently if the file or section was
+    missing.  This version creates the file and the section as needed so that
+    settings can always be persisted.
+    """
+
     try:
-        with open(filename) as galadriel_yaml:
-            current_config = yaml.safe_load(galadriel_yaml)
+        if os.path.exists(filename):
+            with open(filename) as galadriel_yaml:
+                current_config = yaml.safe_load(galadriel_yaml) or {}
+        else:
+            current_config = {}
+
+        # Ensure the section exists and is a dictionary
+        if section not in current_config or not isinstance(current_config[section], dict):
+            current_config[section] = {}
+
         current_config[section][key] = value
+
         with open(filename, "w") as galadriel_yaml:
             yaml.safe_dump(current_config, galadriel_yaml)
-    except:
+    except Exception:
+        # Silently ignore write errors to maintain backward compatible behaviour
         pass

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -1,0 +1,26 @@
+"""Tests for YAML utility helpers."""
+
+from importlib import util
+from pathlib import Path
+import yaml
+
+# Import the YAML utils module directly to avoid executing package side effects
+spec = util.spec_from_file_location(
+    "yaml_utils", Path(__file__).resolve().parents[1] / "galadriel" / "utils" / "yaml.py"
+)
+yaml_utils = util.module_from_spec(spec)
+spec.loader.exec_module(yaml_utils)
+
+
+def test_write_setting_creates_file_and_section(tmp_path):
+    cfg_path = tmp_path / "config.yaml"
+    # No file exists yet, so reading the setting should return None
+    assert yaml_utils.read_setting(str(cfg_path), "galadriel", "first_run") is None
+
+    # After writing, the file and section should be created with the value
+    yaml_utils.write_setting(str(cfg_path), "galadriel", "first_run", 1)
+    assert yaml_utils.read_setting(str(cfg_path), "galadriel", "first_run") == 1
+
+    with cfg_path.open() as f:
+        data = yaml.safe_load(f)
+    assert data["galadriel"]["first_run"] == 1


### PR DESCRIPTION
## Summary
- ensure utils.write_setting creates YAML file and missing sections before persisting values
- add regression test for write_setting behaviour

## Testing
- `pytest tests/test_yaml_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b226743288331a51f1968b4227532