### PR TITLE
Add action log foundation: model, state, page, and helper

### DIFF
--- a/galadriel/audit/__init__.py
+++ b/galadriel/audit/__init__.py
@@ -6,9 +6,9 @@ from .pages import action_log_page
 from .state import ActionLogState
 
 __all__ = [
-    "ActionLogModel",
     "ActionLogDisplay",
-    "action_log_page",
+    "ActionLogModel",
     "ActionLogState",
+    "action_log_page",
     "log_action",
 ]

--- a/galadriel/audit/__init__.py
+++ b/galadriel/audit/__init__.py
@@ -1,0 +1,14 @@
+"""Audit module for action logging."""
+
+from .model import ActionLogModel, ActionLogDisplay
+from .helpers import log_action
+from .pages import action_log_page
+from .state import ActionLogState
+
+__all__ = [
+    "ActionLogModel",
+    "ActionLogDisplay",
+    "action_log_page",
+    "ActionLogState",
+    "log_action",
+]

--- a/galadriel/audit/helpers.py
+++ b/galadriel/audit/helpers.py
@@ -1,0 +1,27 @@
+"""Helper functions for logging user actions."""
+
+import reflex as rx
+
+from .model import ActionLogModel
+
+
+def log_action(
+    user_id: int,
+    username: str,
+    action: str,
+    entity_type: str = "",
+    entity_name: str = "",
+    detail: str = "",
+) -> None:
+    """Record a user action in the audit log."""
+    with rx.session() as session:
+        entry = ActionLogModel(
+            user_id=user_id,
+            username=username,
+            action=action,
+            entity_type=entity_type,
+            entity_name=entity_name,
+            detail=detail,
+        )
+        session.add(entry)
+        session.commit()

--- a/galadriel/audit/model.py
+++ b/galadriel/audit/model.py
@@ -1,0 +1,35 @@
+"""Action log domain model."""
+
+from datetime import datetime
+from typing import Optional
+
+import reflex as rx
+from sqlmodel import Field
+
+from ..utils import timing
+from ..utils.mixins import TimestampMixin
+
+
+class ActionLogModel(TimestampMixin, rx.Model, table=True):
+    """Represents an auditable user action."""
+
+    user_id: int = Field(nullable=False)
+    username: str = Field(nullable=False)
+    action: str = Field(nullable=False)
+    entity_type: str = Field(default="", nullable=False)
+    entity_name: str = Field(default="", nullable=False)
+    detail: str = Field(default="", nullable=False)
+    created: datetime = timing.created_field()
+
+
+class ActionLogDisplay(rx.Model):
+    """Read-only view model for displaying action log entries."""
+
+    log_id: int
+    user_id: int
+    username: str
+    action: str
+    entity_type: str
+    entity_name: str
+    detail: str
+    created: datetime

--- a/galadriel/audit/model.py
+++ b/galadriel/audit/model.py
@@ -1,7 +1,6 @@
 """Action log domain model."""
 
 from datetime import datetime
-from typing import Optional
 
 import reflex as rx
 from sqlmodel import Field

--- a/galadriel/audit/pages.py
+++ b/galadriel/audit/pages.py
@@ -141,19 +141,31 @@ def action_log_page() -> rx.Component:
                 size="2",
                 width="100%",
             ),
-            rx.flex(
-                rx.box(
-                    __entry_table(),
-                    flex="2",
+            rx.desktop_only(
+                rx.flex(
+                    rx.box(
+                        __entry_table(),
+                        flex="2",
+                    ),
+                    rx.box(
+                        __detail_panel(),
+                        flex="1",
+                    ),
+                    direction="row",
+                    spacing="4",
+                    width="100%",
+                    height="100%",
                 ),
-                rx.box(
-                    __detail_panel(),
-                    flex="1",
-                ),
-                direction="row",
-                spacing="4",
                 width="100%",
-                height="100%",
+            ),
+            rx.mobile_and_tablet(
+                rx.vstack(
+                    __entry_table(),
+                    __detail_panel(),
+                    spacing="4",
+                    width="100%",
+                ),
+                width="100%",
             ),
             spacing="5",
             align="center",

--- a/galadriel/audit/pages.py
+++ b/galadriel/audit/pages.py
@@ -1,0 +1,163 @@
+"""Action log page — list + detail layout."""
+
+import reflex as rx
+
+from ..pages import base_page
+from ..ui.components import Badge, Table, Moment
+from ..utils import consts
+from ..auth.state import require_super_admin
+from .state import ActionLogState
+
+
+def __entry_row(entry) -> rx.Component:
+    """Render a single action log row in the list."""
+    moment_component = Moment()
+    return rx.table.row(
+        rx.table.cell(entry.username),
+        rx.table.cell(entry.action),
+        rx.table.cell(entry.entity_type),
+        rx.table.cell(entry.entity_name),
+        rx.table.cell(moment_component.moment(entry.created)),
+        cursor="pointer",
+        on_click=ActionLogState.select_entry(entry.log_id),
+        _hover={"bg": rx.color("accent", 3)},
+    )
+
+
+def __entry_table() -> rx.Component:
+    """Render the action log table."""
+    table_component = Table()
+    return rx.box(
+        rx.table.root(
+            rx.table.header(
+                rx.table.row(
+                    table_component.header("user", "user"),
+                    table_component.header("action", "activity"),
+                    table_component.header("type", "layers"),
+                    table_component.header("name", "tag"),
+                    table_component.header("date", "calendar-clock"),
+                ),
+            ),
+            rx.table.body(
+                rx.foreach(ActionLogState.entries, __entry_row),
+            ),
+            variant="surface",
+            size="3",
+            width="100%",
+        ),
+        class_name="sticky-table",
+        overflow_y="auto",
+        flex="1",
+        min_height="0",
+        width="100%",
+    )
+
+
+def __detail_panel() -> rx.Component:
+    """Render the detail panel for the selected entry."""
+    entry = ActionLogState.selected_entry
+    moment_component = Moment()
+    return rx.cond(
+        entry,
+        rx.card(
+            rx.vstack(
+                rx.hstack(
+                    rx.heading("Action Detail", size="4"),
+                    rx.spacer(),
+                    rx.icon(
+                        "x",
+                        cursor="pointer",
+                        on_click=ActionLogState.clear_selection,
+                    ),
+                    width="100%",
+                    align="center",
+                ),
+                rx.divider(),
+                rx.vstack(
+                    __detail_field("User", entry.username),
+                    __detail_field("Action", entry.action),
+                    __detail_field("Entity Type", entry.entity_type),
+                    __detail_field("Entity Name", entry.entity_name),
+                    __detail_field("Date", moment_component.moment(entry.created)),
+                    rx.cond(
+                        entry.detail,
+                        rx.vstack(
+                            rx.text("Detail", weight="bold", size="2", color=consts.COLOR_MUTED),
+                            rx.text(entry.detail, size="2"),
+                            spacing="1",
+                            width="100%",
+                        ),
+                    ),
+                    spacing="3",
+                    width="100%",
+                ),
+                spacing="3",
+                width="100%",
+            ),
+            width="100%",
+        ),
+        rx.center(
+            rx.text("Select an entry to view details", color=consts.COLOR_MUTED),
+            min_height="200px",
+            width="100%",
+        ),
+    )
+
+
+def __detail_field(label: str, value) -> rx.Component:
+    """Render a label-value pair in the detail panel."""
+    return rx.hstack(
+        rx.text(label, weight="bold", size="2", color=consts.COLOR_MUTED, min_width="100px"),
+        rx.text(value, size="2"),
+        spacing="2",
+        width="100%",
+    )
+
+
+@require_super_admin
+def action_log_page() -> rx.Component:
+    """Render the action log page with list + detail layout."""
+    page_title = Badge()
+
+    return base_page(
+        rx.vstack(
+            rx.flex(
+                page_title.title("scroll-text", "Action Log"),
+                flex_direction=["column", "column", "row"],
+                align="center",
+                width="100%",
+                padding_top="2em",
+                padding_bottom="0.5em",
+                position="sticky",
+                top="0",
+                z_index="3",
+                background_color="var(--color-background)",
+            ),
+            rx.input(
+                rx.input.slot(rx.icon("search", size=16)),
+                placeholder="Search by user, action, type, or name...",
+                value=ActionLogState.search_value,
+                on_change=ActionLogState.filter_entries,
+                size="2",
+                width="100%",
+            ),
+            rx.flex(
+                rx.box(
+                    __entry_table(),
+                    flex="2",
+                ),
+                rx.box(
+                    __detail_panel(),
+                    flex="1",
+                ),
+                direction="row",
+                spacing="4",
+                width="100%",
+                height="100%",
+            ),
+            spacing="5",
+            align="center",
+            width="100%",
+            height="100%",
+        ),
+    )

--- a/galadriel/audit/state.py
+++ b/galadriel/audit/state.py
@@ -4,7 +4,6 @@ import reflex as rx
 from sqlmodel import select, col
 
 from .model import ActionLogModel, ActionLogDisplay
-from ..utils.mixins import TimestampMixin
 
 
 class ActionLogState(rx.State):
@@ -19,7 +18,7 @@ class ActionLogState(rx.State):
         with rx.session() as session:
             query = select(ActionLogModel).order_by(col(ActionLogModel.created).desc())
             if self.search_value:
-                pattern = f"%{self.search_value.lower()}%"
+                pattern = f"%{self.search_value}%"
                 query = query.where(
                     col(ActionLogModel.username).ilike(pattern)
                     | col(ActionLogModel.action).ilike(pattern)

--- a/galadriel/audit/state.py
+++ b/galadriel/audit/state.py
@@ -47,6 +47,7 @@ class ActionLogState(rx.State):
             if entry.log_id == log_id:
                 self.selected_entry = entry
                 return
+        self.selected_entry = None
 
     def clear_selection(self) -> None:
         """Clear the selected entry."""

--- a/galadriel/audit/state.py
+++ b/galadriel/audit/state.py
@@ -1,0 +1,59 @@
+"""Action log state for the audit log page."""
+
+import reflex as rx
+from sqlmodel import select, col
+
+from .model import ActionLogModel, ActionLogDisplay
+from ..utils.mixins import TimestampMixin
+
+
+class ActionLogState(rx.State):
+    """Manages the action log list and detail view."""
+
+    entries: list[ActionLogDisplay] = []
+    selected_entry: ActionLogDisplay | None = None
+    search_value: str = ""
+
+    def load_entries(self) -> None:
+        """Load all action log entries, newest first."""
+        with rx.session() as session:
+            query = select(ActionLogModel).order_by(col(ActionLogModel.created).desc())
+            if self.search_value:
+                pattern = f"%{self.search_value.lower()}%"
+                query = query.where(
+                    col(ActionLogModel.username).ilike(pattern)
+                    | col(ActionLogModel.action).ilike(pattern)
+                    | col(ActionLogModel.entity_type).ilike(pattern)
+                    | col(ActionLogModel.entity_name).ilike(pattern)
+                )
+            rows = session.exec(query).all()
+            self.entries = [
+                ActionLogDisplay(
+                    log_id=r.id,
+                    user_id=r.user_id,
+                    username=r.username,
+                    action=r.action,
+                    entity_type=r.entity_type,
+                    entity_name=r.entity_name,
+                    detail=r.detail,
+                    created=r.created,
+                )
+                for r in rows
+            ]
+        self.selected_entry = None
+
+    def select_entry(self, log_id: int) -> None:
+        """Select an entry by its log id to show in the detail panel."""
+        for entry in self.entries:
+            if entry.log_id == log_id:
+                self.selected_entry = entry
+                return
+
+    def clear_selection(self) -> None:
+        """Clear the selected entry."""
+        self.selected_entry = None
+
+    def filter_entries(self, value: str) -> None:
+        """Update search value and reload entries."""
+        self.search_value = value
+        self.load_entries()

--- a/galadriel/galadriel.py
+++ b/galadriel/galadriel.py
@@ -12,6 +12,7 @@ from . import install
 from . import dashboard
 from . import user
 from . import settings
+from . import audit
 from .utils import consts
 from .utils import yaml  # local yaml.py with PyYAML helpers
 
@@ -111,6 +112,9 @@ app.add_page(dashboard.dashboard_page, route=navigation.routes.DASHBOARD, on_loa
 
 # Settings
 app.add_page(settings.settings_page, route=navigation.routes.SETTINGS, on_load=[Session.on_load, Session.require_super_admin, settings.SettingsState.load_jira_settings])
+
+# Action Log
+app.add_page(audit.action_log_page, route=navigation.routes.ACTION_LOG, on_load=[Session.on_load, Session.require_super_admin, audit.ActionLogState.load_entries])
 
 # Users
 app.add_page(user_add_edit_list.users_list_page, route=navigation.routes.USERS, on_load=[Session.on_load, Session.require_admin, user.UserState.load_users])

--- a/galadriel/navigation/routes.py
+++ b/galadriel/navigation/routes.py
@@ -40,6 +40,7 @@ CYCLE_ITERATION_DETAIL = "/cycles/[id]/iteration"
 DASHBOARD = "/dashboard"
 
 SETTINGS = "/settings"
+ACTION_LOG = "/action-log"
 
 USERS = "/users"
 USER_ADD = "/users/add"

--- a/galadriel/ui/components.py
+++ b/galadriel/ui/components.py
@@ -284,12 +284,15 @@ class SideBar():
         )
 
     def __backoffice_sidebar_items(self) -> rx.Component:
-        """Render backoffice sidebar items (Settings visible only to admin)."""
+        """Render backoffice sidebar items (Settings/Action Log visible only to admin)."""
         return rx.vstack(
             self.__sidebar_item("Users", "users", navigation.routes.USERS),
             rx.cond(
                 Session.is_super_admin,
-                self.__sidebar_item("Settings", "settings", navigation.routes.SETTINGS),
+                rx.fragment(
+                    self.__sidebar_item("Action Log", "scroll-text", navigation.routes.ACTION_LOG),
+                    self.__sidebar_item("Settings", "settings", navigation.routes.SETTINGS),
+                ),
             ),
             spacing="1",
             width="100%",

--- a/galadriel/utils/jira.py
+++ b/galadriel/utils/jira.py
@@ -139,6 +139,10 @@ class JiraClient:
 
         return {issue["key"]: issue for issue in data.get("issues", [])}
 
+    def reset_session(self) -> None:
+        """Clear the cached HTTP session so the next call creates a fresh one."""
+        self._session = None
+
 
 # Singleton client — reuses TCP/TLS connection across calls
 _client = JiraClient()
@@ -281,4 +285,4 @@ def bulk_fetch_issues(issue_keys: list[str], fields: list[str] | None = None) ->
 
 def reset_session() -> None:
     """Clear the cached HTTP session so the next call creates a fresh one."""
-    _client._session = None
+    _client.reset_session()

--- a/galadriel/utils/jira.py
+++ b/galadriel/utils/jira.py
@@ -278,3 +278,7 @@ def get_issue(issue_key):
 def bulk_fetch_issues(issue_keys: list[str], fields: list[str] | None = None) -> dict[str, dict]:
     """Fetch multiple Jira issues in a single request, returning a dict keyed by issue key."""
     return _client.bulk_fetch_issues(issue_keys, fields)
+
+def reset_session() -> None:
+    """Clear the cached HTTP session so the next call creates a fresh one."""
+    _client._session = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from galadriel.iteration.model import (
 )
 from galadriel.user.model import GaladrielUser, GaladrielUserRole
 from galadriel.config.model import ConfigModel
+from galadriel.audit.model import ActionLogModel
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,7 +1,6 @@
 """Tests for galadriel.audit — action log model, helpers, and state."""
 
 import pytest
-from datetime import datetime, timezone
 from sqlmodel import select
 
 from galadriel.audit.model import ActionLogModel

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,138 @@
+"""Tests for galadriel.audit — action log model, helpers, and state."""
+
+import pytest
+from datetime import datetime, timezone
+from sqlmodel import select
+
+from galadriel.audit.model import ActionLogModel
+from galadriel.audit.helpers import log_action
+from galadriel.audit.state import ActionLogState
+from conftest import init_state
+
+pytestmark = pytest.mark.integration
+
+
+class TestLogAction:
+    """Tests for the log_action helper."""
+
+    def test_creates_entry(self, patch_rx_session, seeded_db):
+        """log_action should insert a new ActionLogModel row."""
+        log_action(
+            user_id=1,
+            username="admin",
+            action="created",
+            entity_type="suite",
+            entity_name="Smoke Tests",
+        )
+        session = patch_rx_session
+        rows = session.exec(select(ActionLogModel)).all()
+        assert len(rows) == 1
+        assert rows[0].username == "admin"
+        assert rows[0].action == "created"
+        assert rows[0].entity_type == "suite"
+        assert rows[0].entity_name == "Smoke Tests"
+
+    def test_creates_entry_with_detail(self, patch_rx_session, seeded_db):
+        """log_action should store the detail field."""
+        log_action(
+            user_id=1,
+            username="admin",
+            action="updated",
+            entity_type="case",
+            entity_name="Login Test",
+            detail="Changed name from 'Login' to 'Login Test'",
+        )
+        session = patch_rx_session
+        row = session.exec(select(ActionLogModel)).one()
+        assert row.detail == "Changed name from 'Login' to 'Login Test'"
+
+    def test_creates_entry_minimal(self, patch_rx_session, seeded_db):
+        """log_action should work with only required fields."""
+        log_action(user_id=2, username="editor", action="logged_in")
+        session = patch_rx_session
+        row = session.exec(select(ActionLogModel)).one()
+        assert row.entity_type == ""
+        assert row.entity_name == ""
+        assert row.detail == ""
+
+    def test_created_timestamp_set(self, patch_rx_session, seeded_db):
+        """log_action entries should have a created timestamp."""
+        log_action(user_id=1, username="admin", action="test")
+        session = patch_rx_session
+        row = session.exec(select(ActionLogModel)).one()
+        assert row.created is not None
+
+
+class TestActionLogState:
+    """Tests for ActionLogState load and selection."""
+
+    def _seed_entries(self, session):
+        """Insert sample action log entries."""
+        entries = [
+            ActionLogModel(user_id=1, username="admin", action="created", entity_type="suite", entity_name="Suite A"),
+            ActionLogModel(user_id=2, username="editor", action="updated", entity_type="case", entity_name="Case B"),
+            ActionLogModel(user_id=1, username="admin", action="deleted", entity_type="scenario", entity_name="Scenario C"),
+        ]
+        for e in entries:
+            session.add(e)
+        session.commit()
+
+    def test_load_entries(self, patch_rx_session, seeded_db):
+        """load_entries should populate the entries list."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.load_entries.fn(state)
+        assert len(state.entries) == 3
+
+    def test_load_entries_clears_selection(self, patch_rx_session, seeded_db):
+        """load_entries should clear any selected entry."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.load_entries.fn(state)
+        # Select first entry, then reload
+        ActionLogState.select_entry.fn(state, state.entries[0].log_id)
+        assert state.selected_entry is not None
+        ActionLogState.load_entries.fn(state)
+        assert state.selected_entry is None
+
+    def test_select_entry(self, patch_rx_session, seeded_db):
+        """select_entry should set the selected_entry."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.load_entries.fn(state)
+        first_id = state.entries[0].log_id
+        ActionLogState.select_entry.fn(state, first_id)
+        assert state.selected_entry is not None
+        assert state.selected_entry.log_id == first_id
+
+    def test_clear_selection(self, patch_rx_session, seeded_db):
+        """clear_selection should set selected_entry to None."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.load_entries.fn(state)
+        ActionLogState.select_entry.fn(state, state.entries[0].log_id)
+        ActionLogState.clear_selection.fn(state)
+        assert state.selected_entry is None
+
+    def test_filter_entries_by_username(self, patch_rx_session, seeded_db):
+        """filter_entries should narrow results by username."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.filter_entries.fn(state, "editor")
+        assert len(state.entries) == 1
+        assert state.entries[0].username == "editor"
+
+    def test_filter_entries_by_action(self, patch_rx_session, seeded_db):
+        """filter_entries should narrow results by action."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.filter_entries.fn(state, "deleted")
+        assert len(state.entries) == 1
+        assert state.entries[0].action == "deleted"
+
+    def test_filter_entries_empty_returns_all(self, patch_rx_session, seeded_db):
+        """Empty filter should return all entries."""
+        self._seed_entries(patch_rx_session)
+        state = init_state(ActionLogState, search_value="")
+        ActionLogState.filter_entries.fn(state, "")
+        assert len(state.entries) == 3


### PR DESCRIPTION
Introduces the audit module with ActionLogModel, log_action() helper, admin-only page with list+detail layout, search filtering, and sidebar entry. Also restores missing reset_session() in jira utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action Log page for super administrators: searchable, real-time filtering, selectable entries with a detail panel showing full entry info; visible in the backoffice sidebar.
* **Tests**
  * Added integration tests covering audit logging, state behavior, and UI-loading/filtering of log entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->