### PR TITLE
Wire audit logging into suite state handlers

### DIFF
--- a/galadriel/suite/state.py
+++ b/galadriel/suite/state.py
@@ -42,7 +42,7 @@ class SuiteState(rx.State):
     async def _get_user_info(self) -> tuple[int, str]:
         """Return (user_id, username) from the current session."""
         session_state = await self.get_state(Session)
-        return session_state.authenticated_user.id, session_state.authenticated_user.username
+        return session_state.user_id or 0, session_state.username or "unknown"
 
     @rx.var(cache=True)
     def suite_id(self) -> str:
@@ -244,13 +244,13 @@ class SuiteState(rx.State):
             session.add(case_to_add)
             session.commit()
             session.refresh(case_to_add)
-            case_name = session.exec(CaseModel.select().where(CaseModel.id == case_id)).first()
+            case_obj = session.exec(CaseModel.select().where(CaseModel.id == case_id)).first()
         self.search_case_value = ""
         self.collapse_searches()
         self.load_children()
 
         user_id, username = await self._get_user_info()
-        log_action(user_id, username, "linked", "suite", self.suite.name if self.suite else "", f"case '{case_name.name if case_name else 'unknown'}'")
+        log_action(user_id, username, "linked", "suite", self.suite.name if self.suite else "", f"case '{case_obj.name if case_obj else 'unknown'}'")
 
         return rx.toast.success("case added!")
 

--- a/galadriel/suite/state.py
+++ b/galadriel/suite/state.py
@@ -8,6 +8,8 @@ from ..navigation import routes
 from ..case.model import CaseModel, StepModel
 from ..scenario.model import ScenarioModel
 
+from ..audit.helpers import log_action
+from ..auth.state import Session
 from ..utils import consts
 from ..utils.mixins import reorder_move_up, reorder_move_down, reorder_delete, has_steps as _has_steps, get_max_child_order as _get_max_child_order, toggle_sort_field, sort_items, filter_and_load, populate_step_counts
 
@@ -37,16 +39,21 @@ class SuiteState(rx.State):
     search_sort_by: str = ""
     search_sort_asc: bool = True
 
+    async def _get_user_info(self) -> tuple[int, str]:
+        """Return (user_id, username) from the current session."""
+        session_state = await self.get_state(Session)
+        return session_state.authenticated_user.id, session_state.authenticated_user.username
+
     @rx.var(cache=True)
     def suite_id(self) -> str:
         return self.router._page.params.get(consts.FIELD_ID, "")
-    
+
     @rx.var(cache=True)
     def suite_url(self) -> str:
         if not self.suite:
             return f"{SUITES_ROUTE}"
         return f"{SUITES_ROUTE}/{self.suite.id}"
-    
+
     @rx.var(cache=True)
     def suite_edit_url(self) -> str:
         if not self.suite:
@@ -112,11 +119,11 @@ class SuiteState(rx.State):
             self.suite = suite
 
             return consts.RETURN_VALUE
-    
+
     def save_suite_edits(self, suite_id:int, updated_data:dict):
         """Persist edits to an existing suite."""
         if updated_data["name"] == "": return None
-        with rx.session() as session:        
+        with rx.session() as session:
             suite = session.exec(SuiteModel.select().where(SuiteModel.id == suite_id)).one_or_none()
 
             if (suite is None):
@@ -138,7 +145,7 @@ class SuiteState(rx.State):
         if edit_page:
             return rx.redirect(self.suite_edit_url)
         return rx.redirect(self.suite_url)
-    
+
     def collapse_searches(self):
         """Hide all child search panels."""
         self.show_case_search = False
@@ -167,26 +174,43 @@ class SuiteState(rx.State):
             self.children = results
             self.child_count = len(results)
 
-    def unlink_child(self, suite_child_id:int):
+    def _find_child_info(self, suite_child_id: int) -> tuple[str, str]:
+        """Return (child_type, child_name) for a suite child by its id."""
+        for child in self.children:
+            if child.id == suite_child_id:
+                child_type = "scenario" if child.child_type_id == consts.SUITE_CHILD_TYPE_SCENARIO else "case"
+                return child_type, getattr(child, "child_name", "unknown")
+        return "child", "unknown"
+
+    async def unlink_child(self, suite_child_id:int):
         """Remove a child from this suite and reorder siblings."""
+        child_type, child_name = self._find_child_info(suite_child_id)
         toast = reorder_delete(SuiteChildModel, suite_child_id, "suite_id", self.suite_id, "child")
         self.load_children()
+        user_id, username = await self._get_user_info()
+        log_action(user_id, username, "unlinked", "suite", self.suite.name if self.suite else "", f"{child_type} '{child_name}'")
         return toast
 
-    def move_child_up(self, child_id:int):
+    async def move_child_up(self, child_id:int):
         """Move a suite child one position up."""
+        child_type, child_name = self._find_child_info(child_id)
         toast = reorder_move_up(SuiteChildModel, child_id, "suite_id", self.suite_id, "child")
         if toast is None:
             self.load_children()
+            user_id, username = await self._get_user_info()
+            log_action(user_id, username, "reordered", "suite", self.suite.name if self.suite else "", f"moved {child_type} '{child_name}' up")
         return toast
 
-    def move_child_down(self, child_id:int):
+    async def move_child_down(self, child_id:int):
         """Move a suite child one position down."""
+        child_type, child_name = self._find_child_info(child_id)
         toast = reorder_move_down(SuiteChildModel, child_id, "suite_id", self.suite_id, "child")
         if toast is None:
             self.load_children()
+            user_id, username = await self._get_user_info()
+            log_action(user_id, username, "reordered", "suite", self.suite.name if self.suite else "", f"moved {child_type} '{child_name}' down")
         return toast
-    
+
     def get_max_child_order(self, child_id:int, child_type_id:int):
         """Return the next order value for a new suite child."""
         return _get_max_child_order(SuiteChildModel, "suite_id", self.suite_id, child_id, child_type_id)
@@ -196,7 +220,7 @@ class SuiteState(rx.State):
         filter_and_load(self, CaseModel, "search_case_value", "cases_for_search", search_case_value)
         self.cases_for_search = populate_step_counts(self.cases_for_search, StepModel)
 
-    def link_case(self, case_id:int):
+    async def link_case(self, case_id:int):
         """Link a test case to the current suite."""
         if not _has_steps(StepModel, case_id):
             return rx.toast.error("test case must have at least one step")
@@ -220,12 +244,16 @@ class SuiteState(rx.State):
             session.add(case_to_add)
             session.commit()
             session.refresh(case_to_add)
+            case_name = session.exec(CaseModel.select().where(CaseModel.id == case_id)).first()
         self.search_case_value = ""
         self.collapse_searches()
         self.load_children()
-        
+
+        user_id, username = await self._get_user_info()
+        log_action(user_id, username, "linked", "suite", self.suite.name if self.suite else "", f"case '{case_name.name if case_name else 'unknown'}'")
+
         return rx.toast.success("case added!")
-    
+
     def toggle_scenario_search(self):
         """Toggle the scenario search panel visibility."""
         self.show_scenario_search = not self.show_scenario_search
@@ -238,7 +266,7 @@ class SuiteState(rx.State):
         """Set the scenario search filter (if given) and reload matching scenarios."""
         filter_and_load(self, ScenarioModel, "search_scenario_value", "scenarios_for_search", search_scenario_value)
 
-    def link_scenario(self, scenario_id:int):
+    async def link_scenario(self, scenario_id:int):
         """Link a scenario to the current suite."""
         suite_scenario_data:dict = {"suite_id":""}
         new_scenario_order = 1
@@ -259,23 +287,29 @@ class SuiteState(rx.State):
             session.add(scenario_to_add)
             session.commit()
             session.refresh(scenario_to_add)
+            scenario = session.exec(ScenarioModel.select().where(ScenarioModel.id == scenario_id)).first()
         self.search_scenario_value = ""
         self.collapse_searches()
         self.load_children()
-        
+
+        user_id, username = await self._get_user_info()
+        log_action(user_id, username, "linked", "suite", self.suite.name if self.suite else "", f"scenario '{scenario.name if scenario else 'unknown'}'")
+
         return rx.toast.success("scenario added!")
-    
+
 class AddSuiteState(SuiteState):
     """Handles the add-suite form submission."""
 
     form_data:dict = {}
 
-    def handle_submit(self, form_data):
+    async def handle_submit(self, form_data):
         """Validate and create a new suite from the form."""
         self.form_data = form_data
         result = self.add_suite(form_data)
-        
+
         if result is None: return rx.toast.error("name cannot be empty")
+        user_id, username = await self._get_user_info()
+        log_action(user_id, username, "created", "suite", form_data["name"])
         return rx.redirect(routes.SUITES)
 
 class EditSuiteState(SuiteState):
@@ -283,7 +317,7 @@ class EditSuiteState(SuiteState):
 
     form_data:dict = {}
 
-    def handle_submit(self, form_data):
+    async def handle_submit(self, form_data):
         """Validate and save suite edits from the form."""
         self.form_data = form_data
         try:
@@ -294,4 +328,6 @@ class EditSuiteState(SuiteState):
         result = self.save_suite_edits(suite_id, updated_data)
 
         if result is None: return rx.toast.error("name cannot be empty")
+        user_id, username = await self._get_user_info()
+        log_action(user_id, username, "updated", "suite", form_data["name"])
         return rx.redirect(routes.SUITES)

--- a/tests/test_state_suite.py
+++ b/tests/test_state_suite.py
@@ -1,7 +1,8 @@
 """Tests for galadriel.suite.state — SuiteState business logic."""
 
+import asyncio
 import pytest
-from unittest.mock import PropertyMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 from sqlmodel import select
 
 from galadriel.suite.state import SuiteState
@@ -10,6 +11,22 @@ from galadriel.utils import consts
 from conftest import init_state
 
 pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def mock_audit():
+    """Patch async user info lookup and log_action for all suite tests."""
+    async def fake_get_user_info(self):
+        return (0, "test")
+
+    with patch.object(SuiteState, "_get_user_info", fake_get_user_info), \
+         patch("galadriel.suite.state.log_action"):
+        yield
+
+
+def _run(coro):
+    """Run an async event handler synchronously."""
+    return asyncio.run(coro)
 
 
 def _make_state(suite_id_value=""):
@@ -56,7 +73,7 @@ class TestSuiteChildren:
         suite = make_suite(name="S")
         case = make_case(name="No Steps")
         state = _make_state(suite_id_value=str(suite.id))
-        result = state.link_case(case.id)
+        result = _run(state.link_case(case.id))
         assert result is not None
 
     def test_link_case_success(self, patch_rx_session, make_suite, make_case, make_step):
@@ -65,7 +82,7 @@ class TestSuiteChildren:
         make_step(case_id=case.id, order=1)
         state = _make_state(suite_id_value=str(suite.id))
         state.cases_for_search = []
-        state.link_case(case.id)
+        _run(state.link_case(case.id))
         session = patch_rx_session
         children = session.exec(select(SuiteChildModel).where(SuiteChildModel.suite_id == suite.id)).all()
         assert len(children) == 1
@@ -77,7 +94,7 @@ class TestSuiteChildren:
         scenario = make_scenario(name="SC")
         state = _make_state(suite_id_value=str(suite.id))
         state.scenarios_for_search = []
-        state.link_scenario(scenario.id)
+        _run(state.link_scenario(scenario.id))
         session = patch_rx_session
         children = session.exec(select(SuiteChildModel).where(SuiteChildModel.suite_id == suite.id)).all()
         assert len(children) == 1
@@ -94,7 +111,7 @@ class TestSuiteChildren:
         session.refresh(c1)
 
         state = _make_state(suite_id_value=str(suite.id))
-        state.unlink_child(c1.id)
+        _run(state.unlink_child(c1.id))
 
         remaining = session.exec(
             select(SuiteChildModel).where(SuiteChildModel.suite_id == suite.id).order_by(SuiteChildModel.order)
@@ -114,7 +131,7 @@ class TestSuiteChildren:
         session.refresh(c2)
 
         state = _make_state(suite_id_value=str(suite.id))
-        state.move_child_up(c2.id)
+        _run(state.move_child_up(c2.id))
 
         session.expire_all()
         assert session.exec(select(SuiteChildModel).where(SuiteChildModel.id == c2.id)).first().order == 1
@@ -131,7 +148,7 @@ class TestSuiteChildren:
         session.refresh(c2)
 
         state = _make_state(suite_id_value=str(suite.id))
-        state.move_child_down(c1.id)
+        _run(state.move_child_down(c1.id))
 
         session.expire_all()
         assert session.exec(select(SuiteChildModel).where(SuiteChildModel.id == c1.id)).first().order == 2

--- a/tests/test_state_suite.py
+++ b/tests/test_state_suite.py
@@ -29,11 +29,11 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-_PARENT_FIELDS = dict(
-    suites=[], suite=None, children=[], child=None,
-    cases_for_search=[], show_case_search=False, search_case_value="",
-    scenarios_for_search=[], show_scenario_search=False, search_scenario_value="",
-)
+_PARENT_FIELDS = {
+    "suites": [], "suite": None, "children": [], "child": None,
+    "cases_for_search": [], "show_case_search": False, "search_case_value": "",
+    "scenarios_for_search": [], "show_scenario_search": False, "search_scenario_value": "",
+}
 
 
 def _make_state(suite_id_value=""):

--- a/tests/test_state_suite.py
+++ b/tests/test_state_suite.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, PropertyMock, patch
 from sqlmodel import select
 
-from galadriel.suite.state import SuiteState
+from galadriel.suite.state import SuiteState, AddSuiteState, EditSuiteState
 from galadriel.suite.model import SuiteModel, SuiteChildModel
 from galadriel.utils import consts
 from conftest import init_state
@@ -29,14 +29,26 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+_PARENT_FIELDS = dict(
+    suites=[], suite=None, children=[], child=None,
+    cases_for_search=[], show_case_search=False, search_case_value="",
+    scenarios_for_search=[], show_scenario_search=False, search_scenario_value="",
+)
+
+
 def _make_state(suite_id_value=""):
-    state = init_state(
-        SuiteState,
-        suites=[], suite=None, children=[], child=None,
-        cases_for_search=[], show_case_search=False, search_case_value="",
-        scenarios_for_search=[], show_scenario_search=False, search_scenario_value="",
-    )
+    state = init_state(SuiteState, **_PARENT_FIELDS)
     type(state).suite_id = PropertyMock(return_value=suite_id_value)
+    return state
+
+
+def _make_child_state(child_cls, suite_id_value="", **extra):
+    """Create a child state (AddSuiteState/EditSuiteState) with a wired parent."""
+    parent = init_state(SuiteState, **_PARENT_FIELDS)
+    state = init_state(child_cls, **extra)
+    object.__setattr__(state, "parent_state", parent)
+    if suite_id_value:
+        type(state).suite_id = PropertyMock(return_value=suite_id_value)
     return state
 
 
@@ -161,3 +173,44 @@ class TestSuiteChildren:
         session.commit()
         state = _make_state(suite_id_value=str(suite.id))
         assert state.get_max_child_order(5, consts.SUITE_CHILD_TYPE_SCENARIO) is None
+
+
+class TestAddSuiteHandleSubmit:
+    """Tests for AddSuiteState.handle_submit with audit logging."""
+
+    def test_creates_suite_and_logs(self, patch_rx_session):
+        """handle_submit should create the suite and call log_action."""
+        state = _make_child_state(AddSuiteState, form_data={})
+        with patch("galadriel.suite.state.log_action") as mock_log:
+            _run(state.handle_submit({"name": "New Suite"}))
+            assert state.parent_state.suite is not None
+            assert state.parent_state.suite.name == "New Suite"
+            mock_log.assert_called_once_with(0, "test", "created", "suite", "New Suite")
+
+    def test_empty_name_does_not_log(self, patch_rx_session):
+        """handle_submit with empty name should not call log_action."""
+        state = _make_child_state(AddSuiteState, form_data={})
+        with patch("galadriel.suite.state.log_action") as mock_log:
+            _run(state.handle_submit({"name": ""}))
+            mock_log.assert_not_called()
+
+
+class TestEditSuiteHandleSubmit:
+    """Tests for EditSuiteState.handle_submit with audit logging."""
+
+    def test_edits_suite_and_logs(self, patch_rx_session, make_suite):
+        """handle_submit should save edits and call log_action."""
+        suite = make_suite(name="Old")
+        state = _make_child_state(EditSuiteState, suite_id_value=str(suite.id), form_data={})
+        with patch("galadriel.suite.state.log_action") as mock_log:
+            _run(state.handle_submit({"suite_id": suite.id, "name": "Renamed"}))
+            assert state.parent_state.suite.name == "Renamed"
+            mock_log.assert_called_once_with(0, "test", "updated", "suite", "Renamed")
+
+    def test_empty_name_does_not_log(self, patch_rx_session, make_suite):
+        """handle_submit with empty name should not call log_action."""
+        suite = make_suite(name="S")
+        state = _make_child_state(EditSuiteState, suite_id_value=str(suite.id), form_data={})
+        with patch("galadriel.suite.state.log_action") as mock_log:
+            _run(state.handle_submit({"suite_id": suite.id, "name": ""}))
+            mock_log.assert_not_called()


### PR DESCRIPTION
Logs suite actions with granular action types:
- created: new suite
- updated: edit suite name
- linked: add case/scenario to suite
- unlinked: remove case/scenario from suite
- reordered: move child up/down

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for suite management: creation, editing, linking/unlinking and reordering of suite children now record actions with user info and resolved child names.
* **Tests**
  * Expanded test coverage for suite lifecycle and child operations to validate audit behavior and submission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->