### PR TITLE
Fix step table not refreshing after move up/down

### DIFF
--- a/galadriel/case/detail.py
+++ b/galadriel/case/detail.py
@@ -109,6 +109,7 @@ def __show_step(test_step:model.StepModel):
                 spacing="2",
             )
         ),
+        key=step_id,
     )
 
 def __steps_table() -> rx.Component:

--- a/galadriel/case/state.py
+++ b/galadriel/case/state.py
@@ -237,15 +237,13 @@ class CaseState(rx.State):
     def move_step_up(self, step_id:int):
         """Move a step one position up in the order."""
         toast = reorder_move_up(StepModel, step_id, "case_id", self.case_id, "step")
-        if toast is None:
-            self.load_steps()
+        self.load_steps()
         return toast
 
     def move_step_down(self, step_id:int):
         """Move a step one position down in the order."""
         toast = reorder_move_down(StepModel, step_id, "case_id", self.case_id, "step")
-        if toast is None:
-            self.load_steps()
+        self.load_steps()
         return toast
 
     def load_prerequisites(self):


### PR DESCRIPTION
Add key=step_id to step table rows so React recreates DOM nodes when steps swap positions, fixing default_value inputs not updating. Also call load_steps unconditionally after move operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering stability for case steps with consistent identity tracking during updates.
  * Enhanced reliability of step reordering operations through proper state synchronization after moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->